### PR TITLE
Make the Steam and SteamVR paths configurable

### DIFF
--- a/config.bat
+++ b/config.bat
@@ -28,3 +28,11 @@ set lighthouseConnectionAttempts=2
 :: so it can perform its actions; more frequent polling will use more CPU, but the actions will trigger
 :: sooner after you start/quit SteamVR
 set pollingRate=1
+
+:: steamPath is the path to your Steam install location, this is typically located in
+:: C:\Program Files (x86)\Steam
+set steamPath=C:\Program Files (x86)\Steam
+
+:: steamVrPath is the path to your SteamVR install location, this may be called "SteamVR" or "OpenVR"
+:: and will either appear under your main Steam directory, or your alternate install location
+set steamVrPath=C:\Program Files (x86)\Steam\steamapps\common\SteamVR

--- a/mixedvr-manager.bat
+++ b/mixedvr-manager.bat
@@ -89,14 +89,14 @@ for /L %%i in (1,1,%lighthouseConnectionAttempts%) do (
 if exist userdata\SAVE\save_game_steamvr_home.sav (
 	echo MixedVR-Manager is overwriting the existing SteamVR Home layout with the user specified SteamVR Home...
 	for %%f in (userdata\SAVE\*) do (
-		xcopy /y %%f "C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\game\steamtours\SAVE"
+		xcopy /y %%f "%steamVrPath%\tools\steamvr_environments\game\steamtours\SAVE"
 	)
 )
 
 :: restore SteamVR chaperone bounds state (if the user has added chaperone_info.vrchap)
 if exist userdata\chaperone_info.vrchap (
 	echo MixedVR-Manager is overwriting the existing SteamVR chaperone bounds with the user specified chaperone bounds...
-	xcopy /y userdata\chaperone_info.vrchap "C:\Program Files (x86)\Steam\config"
+	xcopy /y userdata\chaperone_info.vrchap "%steamPath%\config"
 )
 
 :: if we're switching to the running state, then we also need to restart SteamVR now that 


### PR DESCRIPTION
Add steamPath and steamVrPath to config.bat, reference them in mixedvr-manager.bat.

Possibly depending on when you first installed it, Steam seems to call the SteamVR directory "SteamVR" or "OpenVR". It's also possible for this directory to be in a different root to the "config" folder, if you use Steam's alternate drive functionality.