### PR TITLE
Added config option to override USBDeview path if shortcut created to…

### DIFF
--- a/config.bat
+++ b/config.bat
@@ -35,3 +35,7 @@ set steamPath=C:\Program Files (x86)\Steam
 :: and will either appear under your main Steam directory, or your alternate install location
 :: again, just like with the steamPath, don't be concerned if this differs on your system unless you're using the two optional features
 set steamVRPath=%steamPath%\steamapps\common\SteamVR
+
+:: if USB Deview has been whitelisted in UAC by creating a shortcut, replace the below path
+:: to the shortcut (including the .lnk extension)
+set usbDeviewPath=bin\USBDeview.exe

--- a/mixedvr-manager.bat
+++ b/mixedvr-manager.bat
@@ -77,7 +77,8 @@ goto stateChanged
 :: toggle state of the USB that the headset is plugged into
 if "%steamvrStatus%" == "running" (set desiredHMDUSBAction=enable) else (set desiredHMDUSBAction=disable)
 echo MixedVR-Manager is changing state of USB device (the HMD) to /%desiredHMDUSBAction%...
-bin\USBDeview.exe /RunAsAdmin /%desiredHMDUSBAction% "HoloLens Sensors"
+:: bin\USBDeview.exe /RunAsAdmin /%desiredHMDUSBAction% "HoloLens Sensors"
+"%usbDeviewPath%" /RunAsAdmin /%desiredHMDUSBAction% "HoloLens Sensors"
 
 :: toggle lighthouse state
 if "%steamvrStatus%" == "running" (set desiredLighthouseState=on) else (set desiredLighthouseState=off)


### PR DESCRIPTION
The documentation suggests a process for whitelisting USB Deview by adding a scheduled task and a shortcut, so I thought it might be handy to include the USBDeview.exe path in the config so that you can then direct this to the shortcut instead (otherwise it will continue to run the exe directly and trigger UAC?)

I might be mistaken but that seems to be how it was behaving for me.

I might have misused the quotes around the path (assuming the possibility for whitespace in an overridden value) but it seems to trigger fine 

(Amazing utility by the way, already makes a massive difference to getting setup and shutting down - I don't have to mess about stretching behind sofas to switch the basestations off for starters!)