### PR TITLE
support htc vive in usb dongle only mode

### DIFF
--- a/bin/mixedvr-manager.bat
+++ b/bin/mixedvr-manager.bat
@@ -135,7 +135,7 @@ if "%allowLighthouseManagement%" == "true" (
 	)
 	if "%lighthouseVersion%" == "1.0" (
 		rem Run on background and let the script continue
-		START /b "lighthouse-keeper" /d "%mixedVRManagerDirectory%" lighthouse-keeper.exe 1 %desiredLighthouseState% %lighthouseMACAddressList%
+		START /b "lighthouse-keeper" /d "%mixedVRManagerDirectory%" lighthouse-keeper.exe 1 %desiredLighthouseState% %lighthouseMACAddressList% > nul
 	)
 ) else (
 	echo MixedVR-Manager is skipping changing state of the lighthouses to %desiredLighthouseState%, per user's configuration

--- a/config.bat
+++ b/config.bat
@@ -12,6 +12,12 @@ set allowLighthouseManagement=true
 :: if you don't want your HMD to be disabled, set this to false
 set allowHMDManagement=true
 
+:: Option to disable HTC Vive HMD and only use Watchman USB dongles from it as tracker receivers
+:: SteamVR will not detect HTC Vive HDM when this is set to true and other 3rd party HMD can be used
+:: For example Pico 4 with vr desktop
+:: Make sure your HMD is connected whem steamvr is launched
+set disableHTCViveHMD=false
+
 :: specify the MAC addresses of your lighthouses (a.k.a basestations) here, separated by a space
 :: There are two ways to find the MAC addresses: 
 :: * a) download the "Lighthouse Power Management" app (Android only)

--- a/uninstall-mixedvr-manager.bat
+++ b/uninstall-mixedvr-manager.bat
@@ -25,6 +25,13 @@ schtasks /Delete /TN "VR\Mixed VR Manager" /F
 echo MixedVR-Manager is changing state of USB device, the HMD, to /enable just in case it was off...
 "%MixedVRManagerFolder%bin\USBDeview.exe" /RunAsAdmin /enable "HoloLens Sensors"
 
+:: Undo disable of HTC Vive HMD USB
+:: HTC VIVE 			0bb4;2c87
+:: Lighthouse FPGA RX 	28de;2000
+echo MixedVR-Manager is changing state of HTC Vive HMD USB devices to enable in case option was used
+"%mixedVRManagerDirectory%USBDeview.exe" /RunAsAdmin /enable_by_pid 0bb4;2c87
+"%mixedVRManagerDirectory%USBDeview.exe" /RunAsAdmin /enable_by_pid 28de;2000
+
 echo *******************************************************************
 echo *****PLEASE READ***********PLEASE READ**********PLEASE READ********
 echo *******************************************************************
@@ -36,6 +43,4 @@ echo * Send a screenshot of the output to /u/monstermac77 on Reddit, or post it 
 echo *******************************************************************
 echo *****PLEASE READ***********PLEASE READ**********PLEASE READ********
 echo *******************************************************************
-
 timeout 60 >NUL
-


### PR DESCRIPTION
- Add option `disableHTCViveHMD` to disable connected HTC Vive HMD which leaves usb receivers within headset on (watchman)
-  `disableHTCViveHMD=true` will override `allowHMDManagement` to false becacuse HMDManagement can't be active at the same time
- `disableHTCViveHMD` is meant to be used with another headsets when connected HTC Vive HMD hijacks the priority HMD place in SteamVR. For example when using Pico 4 via vr desktop with Vive/index controllers and using HTC Vive HMD as watchman usb receiver for controllers
- Changed comments within if/loops from `::` to `rem` because `::` within if/loops in cmd can cause unwanted behavior. In this case it was spamming `system cannot find the drive specified` and it was picking cmd from :: comment
- `LighthouseManagement` changed to run in background to speed up script progress